### PR TITLE
Honor cgi cmd argument

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -88,7 +88,7 @@ module.exports =
     return env
 
 
-  run: (file, req, res, cm) ->
+  run: (file, req, res, cmd) ->
 
     err = ""
     cmd = cmd || "php-cgi"

--- a/index.js
+++ b/index.js
@@ -113,8 +113,8 @@ module.exports = {
     });
     return env;
   },
-  run: function(file, req, res, cm) {
-    var buf, cmd, err, headerSent, php;
+  run: function(file, req, res, cmd) {
+    var buf, err, headerSent, php;
     err = "";
     cmd = cmd || "php-cgi";
     php = child.spawn(cmd, [], {


### PR DESCRIPTION
For some reason, it does not find `php-cgi` which is installed in `/usr/local/bin` by Homebrew. The workaround is to specify the full command path. I had to fix a typo in the internal `run` function arguments to get this to work.
