### PR TITLE
WordPress fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.*.swp

--- a/index.coffee
+++ b/index.coffee
@@ -88,7 +88,7 @@ module.exports =
     return env
 
 
-  run: (file, req, res, cm) ->
+  run: (file, req, res, cmd) ->
 
     err = ""
     cmd = cmd || "php-cgi"

--- a/index.js
+++ b/index.js
@@ -38,14 +38,11 @@ module.exports = {
       }
       if (isPhpFile) {
         parts.pathInfo += '/' + folder;
-      } else if (/.*?\.php$/.test(folder)) {
+      } else if (/.*?\.php$/.test(folder) || folder.indexOf('.php?') !== -1) {
         isPhpFile = true;
       }
     }
     file = path.join(phpdir, parts.pathname);
-    if (!isPhpFile && file.substr(-1, 1) !== '/') {
-      return callback(false);
-    }
     return fs.stat(file, function(err, stats) {
       if (err) {
         return callback(false);
@@ -114,7 +111,7 @@ module.exports = {
     return env;
   },
   run: function(file, req, res, cmd) {
-    var buf, err, headerSent, php;
+    var buf, data, err, headerSent, php;
     err = "";
     cmd = cmd || "php-cgi";
     php = child.spawn(cmd, [], {
@@ -125,34 +122,27 @@ module.exports = {
     req.resume();
     buf = [];
     headerSent = false;
-    php.stdout.on("data", function(data) {
-      var body, chunk, h, head, header, i, len;
-      if (headerSent) {
-        return buf.push(data);
-      } else {
-        chunk = data.toString('binary');
-        body = chunk.split("\r\n\r\n");
-        if (body.length > 1) {
-          head = body[0].split("\r\n");
-          for (i = 0, len = head.length; i < len; i++) {
-            header = head[i];
-            h = header.split(": ");
-            if (h[0] === "Status") {
-              res.statusCode = parseInt(h[1]);
-            }
-            if (h.length === 2) {
-              res.setHeader(h[0], h[1]);
-            }
-          }
-          headerSent = true;
-          return buf.push(data.slice(body[0].length + 4));
-        } else {
-          return buf.push(data);
-        }
-      }
+    data = null;
+    php.stdout.on("data", function(data_part) {
+      return data = data === null ? data_part : Buffer.concat([data, data_part]);
     });
     php.stdout.on("end", function(code) {
+      var body, chunk, h, head, header, i, len;
       php.stdin.end();
+      chunk = data.toString('binary');
+      body = chunk.split("\r\n\r\n");
+      head = body[0].split("\r\n");
+      for (i = 0, len = head.length; i < len; i++) {
+        header = head[i];
+        h = header.split(": ");
+        if (h[0] === "Status") {
+          res.statusCode = parseInt(h[1]);
+        }
+        if (h.length === 2) {
+          res.setHeader(h[0], h[1]);
+        }
+      }
+      buf.push(data.slice(body[0].length + 4));
       res.status(res.statusCode).send(Buffer.concat(buf));
       return res.end();
     });

--- a/index.js
+++ b/index.js
@@ -113,8 +113,8 @@ module.exports = {
     });
     return env;
   },
-  run: function(file, req, res, cm) {
-    var buf, cmd, err, headerSent, php;
+  run: function(file, req, res, cmd) {
+    var buf, err, headerSent, php;
     err = "";
     cmd = cmd || "php-cgi";
     php = child.spawn(cmd, [], {


### PR DESCRIPTION
Some fixes to the CoffeeScript/Javascript:
- PHP resource with urlencoded parameters
- Do not give up on a directory path
- Wait for the end of PHP output before processing data chunks

Additional fixes:
- Add (g)vim .*.swp files to `.gitignore`
- Includes PR #2: honor `php-cgi` command argument (needed for OSX Homebrew for some reason)
